### PR TITLE
Change Nav to Use position: sticky & More CSS Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ require("top-nav");
 ## Customization
 You can customize the color of the `top-nav` by assigning values to css elements. 
 
-The who css elements that affect `top-nav` are `--top-nav-color` and `--primary-color`.
+The CSS custom properties that affect `top-nav` are `--top-nav-color`,
+`--primary-color`, `--top-nav-padding`, `--top-nav-text-color`.
 
 You can set there values like so
 
@@ -42,5 +43,7 @@ You can set there values like so
     :root {
         --top-nav-color: red; /* if both are set --top-nav-color takes precedence */
         --primary-color: red; 
+        --top-nav-padding: 30px; /* (optional) defaults to 20px */
+        --top-nav-text-color: black; /* (optional) defaults to white */
     }
 ```

--- a/top-nav.js
+++ b/top-nav.js
@@ -8,12 +8,13 @@ template.innerHTML = `
         :host {
             display: block;
             width: 100%;
-            background-color: var( --top-nav-color ,var(--primary-color, #673AB7));
-            padding: 20px;
+            background-color: var(--top-nav-color, var(--primary-color, #673AB7));
+            padding: var(--top-nav-padding, 20px);
             box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
-            color: white;
+            color: var(--top-nav-text-color, white);
             font-size: 1em;
-            position: fixed;
+            position: sticky;
+            top: 0px;
         }
     </style>
     <slot></slot>


### PR DESCRIPTION
I am proposing to update the `<top-nav>` element to use `position: sticky` instead of `position: fixed`. Sticky positioning allows the element to block out space within its parent, while also scrolling properly when the user scrolls and staying at the top of the page. With `position: fixed`, the programmer would have to block out space at the top of the body (or other relevant container element) for the fixed-positioned element. 

In addition, I added two new CSS custom properties to allow more control for a developer working with this element:

  - `--top-nav-padding`: Gives the developer control over the amount of padding on the navigation element
  - `--top-nav-text-color`: Gives the developer control over the text color, which goes nicely with the existing `--top-nav-color` property

---

[position: sticky Compatibility](https://caniuse.com/#feat=css-sticky)